### PR TITLE
Implement residual training pipeline

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -1,0 +1,141 @@
+"""Utilities for preparing gearbox fault diagnosis datasets."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+WINDOW_SIZE = 500
+WINDOW_STEP = 500
+
+
+def read_excel_signals(file_path: Path) -> np.ndarray:
+    """Read a vibration Excel file into a numpy array.
+
+    Parameters
+    ----------
+    file_path: Path
+        The path of the Excel file. Files are expected to contain three columns
+        (speed pulse, vertical vibration, horizontal vibration).
+
+    Returns
+    -------
+    np.ndarray
+        Array of shape (num_samples, num_channels=3).
+    """
+
+    data_frame = pd.read_excel(file_path, header=None)
+    return data_frame.to_numpy(dtype=np.float32)
+
+
+def sliding_window(samples: np.ndarray, window_size: int = WINDOW_SIZE, step: int = WINDOW_STEP) -> np.ndarray:
+    """Convert a long time-series into a stack of windows without overlap."""
+
+    num_points, num_channels = samples.shape
+    windows: List[np.ndarray] = []
+    for start in range(0, num_points - window_size + 1, step):
+        end = start + window_size
+        window = samples[start:end]
+        if window.shape[0] == window_size:
+            windows.append(window)
+    if not windows:
+        return np.empty((0, window_size, num_channels), dtype=np.float32)
+    return np.stack(windows, axis=0).astype(np.float32)
+
+
+def build_dataset_from_directory(
+    directory: Path,
+    label_index: int,
+    window_size: int = WINDOW_SIZE,
+    step: int = WINDOW_STEP,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Load every Excel file in the directory and generate windowed samples."""
+
+    all_samples: List[np.ndarray] = []
+    for excel_path in sorted(directory.glob("*.xlsx")):
+        raw_signals = read_excel_signals(excel_path)
+        windows = sliding_window(raw_signals, window_size, step)
+        if windows.size == 0:
+            continue
+        all_samples.append(windows)
+    if not all_samples:
+        return np.empty((0, window_size, 3), dtype=np.float32), np.empty((0,), dtype=np.int64)
+    samples = np.concatenate(all_samples, axis=0)
+    labels = np.full((samples.shape[0],), label_index, dtype=np.int64)
+    return samples, labels
+
+
+def assemble_dataset(class_dirs: Dict[str, Path]) -> Tuple[np.ndarray, np.ndarray, Dict[str, int]]:
+    """Generate samples and labels for all class directories."""
+
+    samples_list: List[np.ndarray] = []
+    labels_list: List[np.ndarray] = []
+    label_mapping: Dict[str, int] = {}
+
+    for label_idx, (class_name, class_path) in enumerate(sorted(class_dirs.items())):
+        label_mapping[class_name] = label_idx
+        class_samples, class_labels = build_dataset_from_directory(class_path, label_idx)
+        if class_samples.size == 0:
+            continue
+        samples_list.append(class_samples)
+        labels_list.append(class_labels)
+
+    samples = np.concatenate(samples_list, axis=0)
+    labels = np.concatenate(labels_list, axis=0)
+    return samples, labels, label_mapping
+
+
+def create_dataloaders(
+    samples: np.ndarray,
+    labels: np.ndarray,
+    batch_size: int = 32,
+    test_size: float = 0.3,
+    random_state: int = 42,
+) -> Tuple[DataLoader, DataLoader, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split samples into training/testing sets and wrap in DataLoaders."""
+
+    train_indices, test_indices = train_test_split(
+        np.arange(samples.shape[0]),
+        test_size=test_size,
+        random_state=random_state,
+        stratify=labels,
+    )
+    train_samples = torch.tensor(samples[train_indices], dtype=torch.float32)
+    train_labels = torch.tensor(labels[train_indices], dtype=torch.long)
+    test_samples = torch.tensor(samples[test_indices], dtype=torch.float32)
+    test_labels = torch.tensor(labels[test_indices], dtype=torch.long)
+
+    train_dataset = TensorDataset(train_samples, train_labels)
+    test_dataset = TensorDataset(test_samples, test_labels)
+
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
+
+    return train_loader, test_loader, train_samples, train_labels, test_samples, test_labels
+
+
+def save_numpy_dataset(
+    output_path: Path,
+    samples: np.ndarray,
+    labels: np.ndarray,
+    label_mapping: Dict[str, int],
+) -> None:
+    """Persist processed dataset to an ``.npz`` file with meta information."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata = {"label_mapping": label_mapping, "window_size": WINDOW_SIZE, "window_step": WINDOW_STEP}
+    np.savez_compressed(output_path, samples=samples, labels=labels, metadata=json.dumps(metadata))
+
+
+def load_numpy_dataset(dataset_path: Path) -> Tuple[np.ndarray, np.ndarray, Dict[str, int]]:
+    """Load dataset produced by :func:`save_numpy_dataset`."""
+
+    npz_data = np.load(dataset_path, allow_pickle=False)
+    metadata = json.loads(str(npz_data["metadata"]))
+    return npz_data["samples"], npz_data["labels"], metadata["label_mapping"]

--- a/models/batchtst.py
+++ b/models/batchtst.py
@@ -1,0 +1,83 @@
+"""A lightweight BatchTST-inspired transformer for time-series classification."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+
+
+@dataclass
+class BatchTSTConfig:
+    """Configuration for :class:`BatchTSTNet`."""
+
+    input_channels: int
+    num_classes: int
+    patch_len: int = 32
+    stride: int = 16
+    d_model: int = 128
+    num_heads: int = 4
+    num_layers: int = 2
+    dropout: float = 0.1
+
+
+class BatchTSTNet(nn.Module):
+    """Temporal set transformer with learnable class token."""
+
+    def __init__(self, config: BatchTSTConfig, seq_len: int) -> None:
+        super().__init__()
+        self.config = config
+
+        if config.patch_len > seq_len:
+            raise ValueError("patch_len must be <= sequence length")
+
+        self.patch_embed = nn.Conv1d(
+            config.input_channels,
+            config.d_model,
+            kernel_size=config.patch_len,
+            stride=config.stride,
+        )
+
+        with torch.no_grad():
+            dummy = torch.zeros(1, config.input_channels, seq_len)
+            patches = self.patch_embed(dummy)
+            self.num_patches = patches.shape[-1]
+
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, config.d_model))
+        self.pos_embedding = nn.Parameter(torch.zeros(1, self.num_patches + 1, config.d_model))
+        nn.init.trunc_normal_(self.cls_token, std=0.02)
+        nn.init.trunc_normal_(self.pos_embedding, std=0.02)
+
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=config.d_model,
+            nhead=config.num_heads,
+            dim_feedforward=config.d_model * 4,
+            dropout=config.dropout,
+            batch_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=config.num_layers)
+        self.dropout = nn.Dropout(config.dropout)
+        self.norm = nn.LayerNorm(config.d_model)
+        self.classifier = nn.Linear(config.d_model, config.num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (batch, channels, seq_len)
+        patches = self.patch_embed(x)  # (batch, d_model, num_patches)
+        patches = patches.transpose(1, 2)  # (batch, num_patches, d_model)
+
+        cls_tokens = self.cls_token.expand(x.size(0), -1, -1)
+        tokens = torch.cat([cls_tokens, patches], dim=1)
+        tokens = tokens + self.pos_embedding[:, : tokens.size(1)]
+        tokens = self.dropout(tokens)
+
+        encoded = self.encoder(tokens)
+        cls = encoded[:, 0, :]
+        cls = self.norm(cls)
+        logits = self.classifier(cls)
+        return logits
+
+    def count_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+
+__all__ = ["BatchTSTConfig", "BatchTSTNet"]

--- a/models/configurable_convnet.py
+++ b/models/configurable_convnet.py
@@ -1,0 +1,123 @@
+"""Configurable 1D CNN that can be described via a simple JSON file."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+import torch
+import torch.nn as nn
+
+
+@dataclass
+class ConfigurableConvNetConfig:
+    """Configuration for :class:`ConfigurableConvNet`."""
+
+    input_channels: int
+    num_classes: int
+    layers: List[Dict[str, Any]] = field(default_factory=list)
+    dropout: float = 0.1
+
+    @staticmethod
+    def default_layers() -> List[Dict[str, Any]]:
+        return [
+            {"type": "conv", "out_channels": 32, "kernel_size": 7, "stride": 1, "padding": "same"},
+            {"type": "batchnorm"},
+            {"type": "relu"},
+            {"type": "maxpool", "kernel_size": 2},
+            {"type": "conv", "out_channels": 64, "kernel_size": 5, "stride": 1, "padding": "same"},
+            {"type": "batchnorm"},
+            {"type": "relu"},
+            {"type": "maxpool", "kernel_size": 2},
+            {"type": "conv", "out_channels": 128, "kernel_size": 3, "stride": 1, "padding": "same"},
+            {"type": "batchnorm"},
+            {"type": "relu"},
+            {"type": "globalavgpool"},
+        ]
+
+
+class ConfigurableConvNet(nn.Module):
+    """Sequential CNN assembled from a list of layer specifications."""
+
+    def __init__(self, config: ConfigurableConvNetConfig, seq_len: int) -> None:
+        super().__init__()
+        self.config = config
+
+        layers_cfg = config.layers or ConfigurableConvNetConfig.default_layers()
+        layers: List[nn.Module] = []
+        in_channels = config.input_channels
+        current_length = seq_len
+
+        for layer in layers_cfg:
+            layer_type = layer.get("type", "").lower()
+            if layer_type == "conv":
+                out_channels = int(layer["out_channels"])
+                kernel_size = int(layer.get("kernel_size", 3))
+                stride = int(layer.get("stride", 1))
+                padding_value = layer.get("padding", 0)
+                if padding_value == "same":
+                    padding = kernel_size // 2
+                else:
+                    padding = int(padding_value)
+                conv = nn.Conv1d(
+                    in_channels,
+                    out_channels,
+                    kernel_size=kernel_size,
+                    stride=stride,
+                    padding=padding,
+                    bias=layer.get("bias", False),
+                )
+                layers.append(conv)
+                in_channels = out_channels
+                current_length = (current_length + 2 * padding - kernel_size) // stride + 1
+            elif layer_type == "batchnorm":
+                layers.append(nn.BatchNorm1d(in_channels))
+            elif layer_type == "relu":
+                layers.append(nn.ReLU(inplace=True))
+            elif layer_type == "gelu":
+                layers.append(nn.GELU())
+            elif layer_type == "dropout":
+                layers.append(nn.Dropout(float(layer.get("p", config.dropout))))
+            elif layer_type == "maxpool":
+                kernel_size = int(layer.get("kernel_size", 2))
+                stride = int(layer.get("stride", kernel_size))
+                layers.append(nn.MaxPool1d(kernel_size=kernel_size, stride=stride))
+                current_length = (current_length - kernel_size) // stride + 1
+            elif layer_type == "avgpool":
+                kernel_size = int(layer.get("kernel_size", 2))
+                stride = int(layer.get("stride", kernel_size))
+                layers.append(nn.AvgPool1d(kernel_size=kernel_size, stride=stride))
+                current_length = (current_length - kernel_size) // stride + 1
+            elif layer_type == "globalavgpool":
+                layers.append(nn.AdaptiveAvgPool1d(1))
+                current_length = 1
+            elif layer_type == "flatten":
+                layers.append(nn.Flatten())
+            else:
+                raise ValueError(f"Unsupported layer type: {layer_type}")
+
+        self.features = nn.Sequential(*layers)
+        self.dropout = nn.Dropout(config.dropout)
+
+        with torch.no_grad():
+            dummy = torch.zeros(1, config.input_channels, seq_len)
+            features = self.features(dummy)
+            if features.ndim == 3:
+                features = torch.mean(features, dim=-1)
+            self.feature_dim = features.view(1, -1).shape[1]
+
+        self.classifier = nn.Linear(self.feature_dim, config.num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.features(x)
+        if out.ndim == 3:
+            out = out.mean(dim=-1)
+        out = out.view(out.size(0), -1)
+        out = self.dropout(out)
+        out = self.classifier(out)
+        return out
+
+    def count_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+
+__all__ = ["ConfigurableConvNetConfig", "ConfigurableConvNet"]

--- a/models/inception_time.py
+++ b/models/inception_time.py
@@ -1,0 +1,131 @@
+"""InceptionTime-style network for multivariate time-series classification."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+import torch
+import torch.nn as nn
+
+
+@dataclass
+class InceptionTimeConfig:
+    """Configuration for :class:`InceptionTimeNet`."""
+
+    input_channels: int
+    num_classes: int
+    num_blocks: int = 6
+    in_channels: int = 32
+    bottleneck_channels: int = 32
+    kernel_sizes: Tuple[int, int, int] = (9, 19, 39)
+    use_residual: bool = True
+    dropout: float = 0.1
+
+
+class InceptionBlock(nn.Module):
+    """Single inception block with optional residual connection."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        bottleneck_channels: int,
+        kernel_sizes: Iterable[int],
+        use_residual: bool = True,
+    ) -> None:
+        super().__init__()
+        self.use_residual = use_residual
+
+        if in_channels > 1:
+            self.bottleneck = nn.Conv1d(in_channels, bottleneck_channels, kernel_size=1, bias=False)
+        else:
+            self.bottleneck = nn.Identity()
+            bottleneck_channels = in_channels
+
+        conv_layers = []
+        for kernel_size in kernel_sizes:
+            padding = kernel_size // 2
+            conv_layers.append(
+                nn.Conv1d(
+                    bottleneck_channels,
+                    out_channels,
+                    kernel_size=kernel_size,
+                    padding=padding,
+                    bias=False,
+                )
+            )
+        self.branches = nn.ModuleList(conv_layers)
+        self.avg_pool = nn.AvgPool1d(kernel_size=3, stride=1, padding=1)
+        self.pool_conv = nn.Conv1d(in_channels, out_channels, kernel_size=1, bias=False)
+
+        self.batch_norm = nn.BatchNorm1d(out_channels * (len(kernel_sizes) + 1))
+        self.relu = nn.ReLU(inplace=True)
+
+        if self.use_residual:
+            if in_channels == out_channels * (len(kernel_sizes) + 1):
+                self.residual = nn.Identity()
+            else:
+                self.residual = nn.Sequential(
+                    nn.Conv1d(
+                        in_channels,
+                        out_channels * (len(kernel_sizes) + 1),
+                        kernel_size=1,
+                        bias=False,
+                    ),
+                    nn.BatchNorm1d(out_channels * (len(kernel_sizes) + 1)),
+                )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        bottleneck = self.bottleneck(x)
+        branch_outputs = [conv(bottleneck) for conv in self.branches]
+        pooled = self.avg_pool(x)
+        branch_outputs.append(self.pool_conv(pooled))
+
+        out = torch.cat(branch_outputs, dim=1)
+        out = self.batch_norm(out)
+        out = self.relu(out)
+
+        if self.use_residual:
+            out = out + self.residual(x)
+            out = self.relu(out)
+        return out
+
+
+class InceptionTimeNet(nn.Module):
+    """Stacked inception blocks followed by global average pooling."""
+
+    def __init__(self, config: InceptionTimeConfig, seq_len: int) -> None:
+        super().__init__()
+        self.config = config
+
+        layers = []
+        in_channels = config.input_channels
+        out_channels = config.in_channels
+        for block_idx in range(config.num_blocks):
+            block = InceptionBlock(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                bottleneck_channels=config.bottleneck_channels,
+                kernel_sizes=config.kernel_sizes,
+                use_residual=config.use_residual,
+            )
+            layers.append(block)
+            in_channels = out_channels * (len(config.kernel_sizes) + 1)
+        self.features = nn.Sequential(*layers)
+        self.global_pool = nn.AdaptiveAvgPool1d(1)
+        self.dropout = nn.Dropout(config.dropout)
+        self.classifier = nn.Linear(in_channels, config.num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.features(x)
+        out = self.global_pool(out)
+        out = out.view(out.size(0), -1)
+        out = self.dropout(out)
+        out = self.classifier(out)
+        return out
+
+    def count_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+
+__all__ = ["InceptionTimeConfig", "InceptionTimeNet"]

--- a/models/simple_resnet.py
+++ b/models/simple_resnet.py
@@ -1,0 +1,92 @@
+"""Simple residual network for time series classification."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+
+
+@dataclass
+class ResNetConfig:
+    """Configuration container for :class:`SimpleResNet`."""
+
+    input_channels: int
+    num_classes: int
+    base_filters: int = 32
+    num_blocks: int = 3
+    kernel_size: int = 7
+    dropout: float = 0.1
+
+
+class ResidualBlock(nn.Module):
+    """A standard residual block with two 1D convolutions."""
+
+    def __init__(self, in_channels: int, out_channels: int, kernel_size: int, stride: int = 1):
+        super().__init__()
+        padding = kernel_size // 2
+        self.conv1 = nn.Conv1d(in_channels, out_channels, kernel_size, stride=stride, padding=padding, bias=False)
+        self.bn1 = nn.BatchNorm1d(out_channels)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = nn.Conv1d(out_channels, out_channels, kernel_size, padding=padding, bias=False)
+        self.bn2 = nn.BatchNorm1d(out_channels)
+
+        if stride != 1 or in_channels != out_channels:
+            self.shortcut = nn.Sequential(
+                nn.Conv1d(in_channels, out_channels, kernel_size=1, stride=stride, bias=False),
+                nn.BatchNorm1d(out_channels),
+            )
+        else:
+            self.shortcut = nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = out + self.shortcut(x)
+        out = self.relu(out)
+        return out
+
+
+class SimpleResNet(nn.Module):
+    """A lightweight residual network for vibration signal classification."""
+
+    def __init__(self, config: ResNetConfig, seq_len: int):
+        super().__init__()
+        self.config = config
+
+        layers = []
+        in_channels = config.input_channels
+        out_channels = config.base_filters
+        for block_idx in range(config.num_blocks):
+            stride = 2 if block_idx > 0 else 1
+            layers.append(ResidualBlock(in_channels, out_channels, config.kernel_size, stride=stride))
+            in_channels = out_channels
+            out_channels *= 2
+        self.features = nn.Sequential(*layers)
+        self.global_pool = nn.AdaptiveAvgPool1d(1)
+        self.dropout = nn.Dropout(config.dropout)
+
+        with torch.no_grad():
+            dummy = torch.zeros(1, config.input_channels, seq_len)
+            feature_tensor = self.global_pool(self.features(dummy))
+            self.feature_length = feature_tensor.shape[1]
+
+        self.classifier = nn.Linear(self.feature_length, config.num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.features(x)
+        out = self.global_pool(out)
+        out = out.view(out.size(0), -1)
+        out = self.dropout(out)
+        out = self.classifier(out)
+        return out
+
+    def count_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+
+__all__ = ["ResNetConfig", "SimpleResNet"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ torch==1.13.1
 scikit-learn==1.1.3
 plotly==5.11.0
 kaleido==0.2.1
+pandas==1.5.3
+matplotlib==3.6.2
+seaborn==0.12.2

--- a/train_res_model.py
+++ b/train_res_model.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import argparse
+import copy
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -14,29 +16,89 @@ import torch.optim as optim
 from sklearn.metrics import confusion_matrix, f1_score
 from sklearn.manifold import TSNE
 
-from data_processing import (
-    assemble_dataset,
-    create_dataloaders,
-    load_numpy_dataset,
-    save_numpy_dataset,
-)
+from data_processing import assemble_dataset, create_dataloaders, load_numpy_dataset, save_numpy_dataset
 from models.simple_resnet import ResNetConfig, SimpleResNet
 
 
 plt.switch_backend("Agg")
 
 
+@dataclass
+class TrainingHyperParameters:
+    """Central place to tweak training behaviour.
+
+    Attributes
+    ----------
+    batch_size:
+        每个 mini-batch 包含的样本数；增大能提高吞吐但需要更多显存/内存。
+    epochs:
+        针对一次训练运行的完整数据遍历次数。
+    learning_rate:
+        Adam 优化器的基础学习率，决定参数更新幅度。
+    weight_decay:
+        L2 正则化强度，用于抑制过拟合（Adam 的 ``weight_decay`` 参数）。
+    test_size:
+        划分为最终测试集的数据比例。
+    val_size:
+        划分为验证集的数据比例（从训练剩余部分中切分，用于调参与早停）。
+    random_state:
+        控制 ``train_test_split`` 随机性的随机种子，便于结果复现。
+    """
+
+    batch_size: int = 32
+    epochs: int = 5
+    learning_rate: float = 1e-3
+    weight_decay: float = 1e-4
+    test_size: float = 0.2
+    val_size: float = 0.1
+    random_state: int = 42
+
+
+HYPERPARAMETER_DESCRIPTIONS: Dict[str, str] = {
+    "batch_size": "每个迭代喂入网络的样本数量，影响训练稳定性和显存占用。",
+    "epochs": "一次 run 内训练集被完整遍历的次数。",
+    "learning_rate": "优化器更新步长，过大易发散，过小收敛慢。",
+    "weight_decay": "对网络权重的L2惩罚系数，用于正则化。",
+    "test_size": "整体数据中用于最终评估的比例。",
+    "val_size": "整体数据中用于验证调参的比例。",
+    "random_state": "划分训练/验证/测试集时的随机种子。",
+}
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--data-root", type=Path, default=Path("初赛数据集A/A/初赛数据集(6种)/初赛训练集"), help="Root directory containing class folders.")
     parser.add_argument("--cache", type=Path, default=Path("processed/dataset.npz"), help="Optional cache path for processed dataset.")
-    parser.add_argument("--batch-size", type=int, default=32, help="Batch size for the DataLoader.")
-    parser.add_argument("--epochs", type=int, default=5, help="Training epochs per run.")
-    parser.add_argument("--learning-rate", type=float, default=1e-3, help="Learning rate for Adam optimizer.")
+    parser.add_argument("--batch-size", type=int, default=TrainingHyperParameters.batch_size, help="Override default batch size.")
+    parser.add_argument("--epochs", type=int, default=TrainingHyperParameters.epochs, help="Training epochs per run.")
+    parser.add_argument("--learning-rate", type=float, default=TrainingHyperParameters.learning_rate, help="Learning rate for Adam optimizer.")
+    parser.add_argument("--weight-decay", type=float, default=TrainingHyperParameters.weight_decay, help="Weight decay (L2 regularisation strength).")
+    parser.add_argument("--test-size", type=float, default=TrainingHyperParameters.test_size, help="Fraction reserved for test set.")
+    parser.add_argument("--val-size", type=float, default=TrainingHyperParameters.val_size, help="Fraction reserved for validation set.")
+    parser.add_argument("--random-state", type=int, default=TrainingHyperParameters.random_state, help="Seed for deterministic dataset splits.")
     parser.add_argument("--num-runs", type=int, default=3, help="Number of repeated experiments.")
     parser.add_argument("--tsne", action="store_true", help="Whether to produce a TSNE visualization from the test set features.")
     parser.add_argument("--no-cache", action="store_true", help="Ignore cached dataset even if it exists.")
     return parser.parse_args()
+
+
+def build_hyperparameters(args: argparse.Namespace) -> TrainingHyperParameters:
+    return TrainingHyperParameters(
+        batch_size=args.batch_size,
+        epochs=args.epochs,
+        learning_rate=args.learning_rate,
+        weight_decay=args.weight_decay,
+        test_size=args.test_size,
+        val_size=args.val_size,
+        random_state=args.random_state,
+    )
+
+
+def describe_hyperparameters(config: TrainingHyperParameters) -> None:
+    print("\n==== 当前可调训练超参数 ====")
+    for key, value in asdict(config).items():
+        description = HYPERPARAMETER_DESCRIPTIONS.get(key, "")
+        print(f"{key:>12}: {value:<10} -> {description}")
 
 
 def discover_class_directories(data_root: Path) -> Dict[str, Path]:
@@ -63,12 +125,25 @@ def prepare_dataset(args: argparse.Namespace) -> Tuple[np.ndarray, np.ndarray, D
 def train_model(
     model: nn.Module,
     train_loader: torch.utils.data.DataLoader,
+    val_loader: torch.utils.data.DataLoader,
     criterion: nn.Module,
     optimizer: optim.Optimizer,
     device: torch.device,
     epochs: int,
-) -> None:
-    """Train the model while printing epoch loss."""
+) -> Tuple[Dict[str, float], Dict[str, float]]:
+    """Train the model while tracking the best validation performance.
+
+    Returns
+    -------
+    best_metrics: Dict[str, float]
+        记录最佳验证集表现的指标。
+    history: Dict[str, float]
+        包含最终一个 epoch 的训练损失等信息，用于日志打印。
+    """
+
+    best_state = copy.deepcopy(model.state_dict())
+    best_metrics = {"val_accuracy": 0.0, "val_f1": 0.0, "epoch": 0}
+    history = {}
 
     for epoch in range(epochs):
         model.train()
@@ -87,14 +162,29 @@ def train_model(
             epoch_loss += loss.item()
             total_batches += 1
         avg_loss = epoch_loss / max(total_batches, 1)
-        print(f"Epoch {epoch + 1}/{epochs}, Loss={avg_loss:.4f}")
+
+        val_accuracy, val_f1, *_ = evaluate_model(model, val_loader, device, return_features=False)
+        print(
+            f"Epoch {epoch + 1}/{epochs}, Loss={avg_loss:.4f}, "
+            f"ValAcc={val_accuracy:.2f}%, ValF1={val_f1:.4f}"
+        )
+
+        if val_f1 > best_metrics["val_f1"]:
+            best_state = copy.deepcopy(model.state_dict())
+            best_metrics = {"val_accuracy": val_accuracy, "val_f1": val_f1, "epoch": epoch + 1}
+
+        history = {"epoch_loss": avg_loss, "val_accuracy": val_accuracy, "val_f1": val_f1}
+
+    model.load_state_dict(best_state)
+    return best_metrics, history
 
 
 def evaluate_model(
     model: nn.Module,
     data_loader: torch.utils.data.DataLoader,
     device: torch.device,
-) -> Tuple[float, float, np.ndarray, np.ndarray, np.ndarray]:
+    return_features: bool = True,
+) -> Tuple[float, float, np.ndarray, np.ndarray, Optional[np.ndarray]]:
     """Evaluate accuracy and macro F1 score on the provided loader."""
 
     model.eval()
@@ -111,13 +201,18 @@ def evaluate_model(
 
             all_labels.extend(targets.cpu().numpy().tolist())
             all_preds.extend(predictions.cpu().numpy().tolist())
-            feature_storage.append(logits.cpu().numpy())
+            if return_features:
+                feature_storage.append(logits.cpu().numpy())
 
     all_labels_array = np.array(all_labels)
     all_preds_array = np.array(all_preds)
     accuracy = (all_labels_array == all_preds_array).mean() * 100
     f1_macro = f1_score(all_labels_array, all_preds_array, average="macro")
-    features = np.concatenate(feature_storage, axis=0)
+    features: Optional[np.ndarray]
+    if return_features and feature_storage:
+        features = np.concatenate(feature_storage, axis=0)
+    else:
+        features = None
     return accuracy, f1_macro, all_labels_array, all_preds_array, features
 
 
@@ -157,13 +252,29 @@ def main() -> None:
     seq_len = samples.shape[1]
     input_channels = samples.shape[2]
 
-    train_loader, test_loader, *_ = create_dataloaders(samples, labels, batch_size=args.batch_size)
+    hyperparams = build_hyperparameters(args)
+    describe_hyperparameters(hyperparams)
+
+    (
+        train_loader,
+        val_loader,
+        test_loader,
+        *_
+    ) = create_dataloaders(
+        samples,
+        labels,
+        batch_size=hyperparams.batch_size,
+        test_size=hyperparams.test_size,
+        val_size=hyperparams.val_size,
+        random_state=hyperparams.random_state,
+    )
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print("当前使用的设备:", device)
 
     acc_list: List[float] = []
     f1_list: List[float] = []
+    best_val_runs: List[Dict[str, float]] = []
     features_runs: List[np.ndarray] = []
     labels_runs: List[np.ndarray] = []
 
@@ -172,15 +283,34 @@ def main() -> None:
         config = ResNetConfig(input_channels=input_channels, num_classes=len(class_names))
         model = SimpleResNet(config, seq_len=seq_len).to(device)
         criterion = nn.CrossEntropyLoss()
-        optimizer = optim.Adam(model.parameters(), lr=args.learning_rate)
+        optimizer = optim.Adam(
+            model.parameters(),
+            lr=hyperparams.learning_rate,
+            weight_decay=hyperparams.weight_decay,
+        )
 
         print(f"模型参数量: {model.count_parameters():,}")
-        train_model(model, train_loader, criterion, optimizer, device, epochs=args.epochs)
+        best_metrics, _ = train_model(
+            model,
+            train_loader,
+            val_loader,
+            criterion,
+            optimizer,
+            device,
+            epochs=hyperparams.epochs,
+        )
+        print(
+            "最佳验证表现 -> "
+            f"Epoch={best_metrics['epoch']}, ValAcc={best_metrics['val_accuracy']:.2f}%, "
+            f"ValF1={best_metrics['val_f1']:.4f}"
+        )
+        best_val_runs.append(best_metrics.copy())
 
         accuracy, f1_macro, all_labels, all_preds, features = evaluate_model(model, test_loader, device)
         acc_list.append(accuracy)
         f1_list.append(f1_macro)
-        features_runs.append(features)
+        if features is not None:
+            features_runs.append(features)
         labels_runs.append(all_labels)
         print(f"第{run}次评估结果: Accuracy={accuracy:.2f}%, F1-macro={f1_macro:.4f}")
 
@@ -188,15 +318,22 @@ def main() -> None:
         plot_confusion(all_labels, all_preds, class_names, cm_path)
         print(f"混淆矩阵已保存至 {cm_path}")
 
-        if args.tsne:
+        if args.tsne and features is not None:
             tsne_path = Path("outputs") / f"tsne_run_{run}.png"
             plot_tsne(features, all_labels, class_names, tsne_path)
             print(f"t-SNE 图已保存至 {tsne_path}")
 
-    print("\n==== 三次训练结果平均值 ====")
+    print("\n==== 每次训练的最佳验证表现 ====")
+    for idx, metrics in enumerate(best_val_runs, start=1):
+        print(
+            f"Run {idx}: BestEpoch={metrics['epoch']}, "
+            f"ValAcc={metrics['val_accuracy']:.2f}%, ValF1={metrics['val_f1']:.4f}"
+        )
+
+    print("\n==== 测试集指标平均值 ====")
     for idx, (acc, f1_macro) in enumerate(zip(acc_list, f1_list), start=1):
         print(f"Run {idx}: Accuracy={acc:.2f}%, F1-macro={f1_macro:.4f}")
-    print(f"\n平均 Accuracy = {np.mean(acc_list):.2f}%")
+    print(f"平均 Accuracy = {np.mean(acc_list):.2f}%")
     print(f"平均 F1-macro = {np.mean(f1_list):.4f}")
 
     if args.tsne and features_runs:

--- a/train_res_model.py
+++ b/train_res_model.py
@@ -1,0 +1,211 @@
+"""Training script for gearbox fault diagnosis using a simple residual network."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import seaborn as sns
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from sklearn.metrics import confusion_matrix, f1_score
+from sklearn.manifold import TSNE
+
+from data_processing import (
+    assemble_dataset,
+    create_dataloaders,
+    load_numpy_dataset,
+    save_numpy_dataset,
+)
+from models.simple_resnet import ResNetConfig, SimpleResNet
+
+
+plt.switch_backend("Agg")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-root", type=Path, default=Path("初赛数据集A/A/初赛数据集(6种)/初赛训练集"), help="Root directory containing class folders.")
+    parser.add_argument("--cache", type=Path, default=Path("processed/dataset.npz"), help="Optional cache path for processed dataset.")
+    parser.add_argument("--batch-size", type=int, default=32, help="Batch size for the DataLoader.")
+    parser.add_argument("--epochs", type=int, default=5, help="Training epochs per run.")
+    parser.add_argument("--learning-rate", type=float, default=1e-3, help="Learning rate for Adam optimizer.")
+    parser.add_argument("--num-runs", type=int, default=3, help="Number of repeated experiments.")
+    parser.add_argument("--tsne", action="store_true", help="Whether to produce a TSNE visualization from the test set features.")
+    parser.add_argument("--no-cache", action="store_true", help="Ignore cached dataset even if it exists.")
+    return parser.parse_args()
+
+
+def discover_class_directories(data_root: Path) -> Dict[str, Path]:
+    class_dirs: Dict[str, Path] = {}
+    for item in sorted(data_root.iterdir()):
+        if item.is_dir():
+            class_dirs[item.name] = item
+    if not class_dirs:
+        raise FileNotFoundError(f"No class directories found under {data_root}.")
+    return class_dirs
+
+
+def prepare_dataset(args: argparse.Namespace) -> Tuple[np.ndarray, np.ndarray, Dict[str, int]]:
+    if args.cache.exists() and not args.no_cache:
+        print(f"Loading cached dataset from {args.cache}...")
+        return load_numpy_dataset(args.cache)
+
+    class_dirs = discover_class_directories(args.data_root)
+    samples, labels, label_mapping = assemble_dataset(class_dirs)
+    save_numpy_dataset(args.cache, samples, labels, label_mapping)
+    return samples, labels, label_mapping
+
+
+def train_model(
+    model: nn.Module,
+    train_loader: torch.utils.data.DataLoader,
+    criterion: nn.Module,
+    optimizer: optim.Optimizer,
+    device: torch.device,
+    epochs: int,
+) -> None:
+    """Train the model while printing epoch loss."""
+
+    for epoch in range(epochs):
+        model.train()
+        epoch_loss = 0.0
+        total_batches = 0
+        for inputs, targets in train_loader:
+            inputs = inputs.permute(0, 2, 1).to(device)
+            targets = targets.to(device)
+
+            optimizer.zero_grad()
+            outputs = model(inputs)
+            loss = criterion(outputs, targets)
+            loss.backward()
+            optimizer.step()
+
+            epoch_loss += loss.item()
+            total_batches += 1
+        avg_loss = epoch_loss / max(total_batches, 1)
+        print(f"Epoch {epoch + 1}/{epochs}, Loss={avg_loss:.4f}")
+
+
+def evaluate_model(
+    model: nn.Module,
+    data_loader: torch.utils.data.DataLoader,
+    device: torch.device,
+) -> Tuple[float, float, np.ndarray, np.ndarray, np.ndarray]:
+    """Evaluate accuracy and macro F1 score on the provided loader."""
+
+    model.eval()
+    all_labels: List[int] = []
+    all_preds: List[int] = []
+    feature_storage: List[np.ndarray] = []
+
+    with torch.no_grad():
+        for inputs, targets in data_loader:
+            inputs = inputs.permute(0, 2, 1).to(device)
+            targets = targets.to(device)
+            logits = model(inputs)
+            predictions = torch.argmax(logits, dim=1)
+
+            all_labels.extend(targets.cpu().numpy().tolist())
+            all_preds.extend(predictions.cpu().numpy().tolist())
+            feature_storage.append(logits.cpu().numpy())
+
+    all_labels_array = np.array(all_labels)
+    all_preds_array = np.array(all_preds)
+    accuracy = (all_labels_array == all_preds_array).mean() * 100
+    f1_macro = f1_score(all_labels_array, all_preds_array, average="macro")
+    features = np.concatenate(feature_storage, axis=0)
+    return accuracy, f1_macro, all_labels_array, all_preds_array, features
+
+
+def plot_confusion(all_labels: np.ndarray, all_preds: np.ndarray, class_names: List[str], output_path: Path) -> None:
+    matrix = confusion_matrix(all_labels, all_preds)
+    plt.figure(figsize=(8, 6))
+    sns.heatmap(matrix, annot=True, fmt="d", cmap="Blues", xticklabels=class_names, yticklabels=class_names)
+    plt.xlabel("Predicted")
+    plt.ylabel("True")
+    plt.title("Confusion Matrix")
+    plt.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(output_path)
+    plt.close()
+
+
+def plot_tsne(features: np.ndarray, labels: np.ndarray, class_names: List[str], output_path: Path) -> None:
+    tsne = TSNE(n_components=2, init="random", random_state=42, perplexity=30)
+    embedding = tsne.fit_transform(features)
+    plt.figure(figsize=(8, 6))
+    for idx, class_name in enumerate(class_names):
+        mask = labels == idx
+        plt.scatter(embedding[mask, 0], embedding[mask, 1], label=class_name, alpha=0.6)
+    plt.legend()
+    plt.title("t-SNE of Test Set Features")
+    plt.tight_layout()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(output_path)
+    plt.close()
+
+
+def main() -> None:
+    args = parse_args()
+
+    samples, labels, label_mapping = prepare_dataset(args)
+    class_names = [name for name, _ in sorted(label_mapping.items(), key=lambda item: item[1])]
+    seq_len = samples.shape[1]
+    input_channels = samples.shape[2]
+
+    train_loader, test_loader, *_ = create_dataloaders(samples, labels, batch_size=args.batch_size)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print("当前使用的设备:", device)
+
+    acc_list: List[float] = []
+    f1_list: List[float] = []
+    features_runs: List[np.ndarray] = []
+    labels_runs: List[np.ndarray] = []
+
+    for run in range(1, args.num_runs + 1):
+        print(f"\n==== 第 {run} 次训练 ====")
+        config = ResNetConfig(input_channels=input_channels, num_classes=len(class_names))
+        model = SimpleResNet(config, seq_len=seq_len).to(device)
+        criterion = nn.CrossEntropyLoss()
+        optimizer = optim.Adam(model.parameters(), lr=args.learning_rate)
+
+        print(f"模型参数量: {model.count_parameters():,}")
+        train_model(model, train_loader, criterion, optimizer, device, epochs=args.epochs)
+
+        accuracy, f1_macro, all_labels, all_preds, features = evaluate_model(model, test_loader, device)
+        acc_list.append(accuracy)
+        f1_list.append(f1_macro)
+        features_runs.append(features)
+        labels_runs.append(all_labels)
+        print(f"第{run}次评估结果: Accuracy={accuracy:.2f}%, F1-macro={f1_macro:.4f}")
+
+        cm_path = Path("outputs") / f"confusion_matrix_run_{run}.png"
+        plot_confusion(all_labels, all_preds, class_names, cm_path)
+        print(f"混淆矩阵已保存至 {cm_path}")
+
+        if args.tsne:
+            tsne_path = Path("outputs") / f"tsne_run_{run}.png"
+            plot_tsne(features, all_labels, class_names, tsne_path)
+            print(f"t-SNE 图已保存至 {tsne_path}")
+
+    print("\n==== 三次训练结果平均值 ====")
+    for idx, (acc, f1_macro) in enumerate(zip(acc_list, f1_list), start=1):
+        print(f"Run {idx}: Accuracy={acc:.2f}%, F1-macro={f1_macro:.4f}")
+    print(f"\n平均 Accuracy = {np.mean(acc_list):.2f}%")
+    print(f"平均 F1-macro = {np.mean(f1_list):.4f}")
+
+    if args.tsne and features_runs:
+        avg_features = np.concatenate(features_runs, axis=0)
+        avg_labels = np.concatenate(labels_runs, axis=0)
+        tsne_path = Path("outputs") / "tsne_overall.png"
+        plot_tsne(avg_features, avg_labels, class_names, tsne_path)
+        print(f"平均 t-SNE 图已保存至 {tsne_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add reusable data preparation utilities that slice Excel vibration signals into sliding windows
- implement a lightweight 1D residual network classifier tailored to the competition data format
- provide a full training script that handles caching, repeated experiments, evaluation metrics, and visualization outputs
- document extra Python dependencies required for the workflow

## Testing
- `python train_res_model.py --epochs 1 --num-runs 1 --no-cache` *(fails: missing matplotlib dependency due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ce3907b48327992c0abd51a148f4