### PR TITLE
Add modular classification training framework

### DIFF
--- a/classification/README.md
+++ b/classification/README.md
@@ -1,0 +1,117 @@
+# 通用分类模型训练框架
+
+本目录提供了一个以 PyTorch 为核心、组件可插拔的通用深度学习分类训练脚手架。通过配置文件即可切换不同的数据加载器、模型和优化器，方便快速实验。
+
+## 目录结构
+
+- `config.py`：定义训练、数据和模型相关的配置数据类，以及 JSON 配置文件的加载逻辑。
+- `data.py`：包含数据模块协议定义和一个基于 `sklearn.make_classification` 的示例数据模块 `ToyClassificationDataModule`。
+- `models.py`：给出简单的 MLP 分类器示例实现，可替换为任意自定义模型。
+- `trainer.py`：训练循环的核心实现，负责模型训练、验证、测试及模型保存。
+- `__init__.py`：便于外部直接导入关键组件。
+
+## 快速开始
+
+1. 安装依赖（若尚未安装）：
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. 查看或修改示例配置文件 `configs/toy_classification.json`，配置项包括：
+   - `dataset.target`：数据模块的导入路径，默认为 `classification.data.ToyClassificationDataModule`。
+   - `model.target`：模型类的导入路径，默认为 `classification.models.MLPClassifier`。
+   - `optimizer.target`：优化器的导入路径（例如 `torch.optim.Adam`）。
+   - `params`：对应模块初始化时需要的参数，采用 JSON 格式传入。
+
+3. 运行训练：
+
+   ```bash
+   python train_classifier.py --config configs/toy_classification.json
+   ```
+
+   训练完成后会在 `output_dir` 指定的目录下生成最优模型的 `best_model.pt`。
+
+## 替换数据模块
+
+要接入自定义数据集，只需编写满足 `ClassificationDataModule` 协议的数据模块。例如：
+
+```python
+from torch.utils.data import DataLoader
+
+class MyDataModule:
+    num_classes = 10
+    input_shape = (3, 32, 32)
+
+    def __init__(self, data_dir: str, batch_size: int = 64) -> None:
+        self._train_loader = DataLoader(...)
+        self._val_loader = DataLoader(...)
+        self._test_loader = DataLoader(...)
+
+    def train_dataloader(self) -> DataLoader:
+        return self._train_loader
+
+    def val_dataloader(self) -> DataLoader:
+        return self._val_loader
+
+    def test_dataloader(self) -> DataLoader:
+        return self._test_loader
+```
+
+将类保存为 `my_project/data.py` 后，在配置文件中设置：
+
+```json
+"dataset": {
+  "target": "my_project.data.MyDataModule",
+  "params": {"data_dir": "./data", "batch_size": 64}
+}
+```
+
+## 替换模型
+
+自定义模型只需继承 `torch.nn.Module`，接收配置文件中的参数，输出形状为 `[batch_size, num_classes]` 的张量即可。例如：
+
+```python
+import torch.nn as nn
+
+class MyNet(nn.Module):
+    def __init__(self, in_features: int, num_classes: int) -> None:
+        super().__init__()
+        self.layers = nn.Sequential(
+            nn.Linear(in_features, 128),
+            nn.ReLU(),
+            nn.Linear(128, num_classes)
+        )
+
+    def forward(self, x):
+        return self.layers(x)
+```
+
+配置文件中设置：
+
+```json
+"model": {
+  "target": "my_project.models.MyNet",
+  "params": {"in_features": 32, "num_classes": 4}
+}
+```
+
+## 学习率调度器
+
+可选地配置学习率调度器：
+
+```json
+"scheduler": {
+  "target": "torch.optim.lr_scheduler.StepLR",
+  "params": {"step_size": 5, "gamma": 0.5}
+}
+```
+
+只要对应的类在运行环境中可导入，训练器会自动实例化并在每个 epoch 末调用 `step()`。
+
+## 输出
+
+- `best_model.pt`：保存验证集上性能最优的模型及优化器状态，便于继续训练或推理。
+- 终端日志：包含每个 epoch 的训练/验证损失与准确率，以及测试集评估结果（若提供测试集）。
+
+通过这种模块化的设计，可以快速尝试不同的数据加载方式、模型结构和优化策略，构建适用于多种任务的分类训练流程。

--- a/classification/__init__.py
+++ b/classification/__init__.py
@@ -1,0 +1,16 @@
+"""Utilities for training interchangeable classification models."""
+
+from .config import TrainingConfig, OptimConfig, ObjectConfig
+from .data import ClassificationDataModule, ToyClassificationDataModule
+from .models import MLPClassifier
+from .trainer import Trainer
+
+__all__ = [
+    "TrainingConfig",
+    "OptimConfig",
+    "ObjectConfig",
+    "ClassificationDataModule",
+    "ToyClassificationDataModule",
+    "MLPClassifier",
+    "Trainer",
+]

--- a/classification/config.py
+++ b/classification/config.py
@@ -1,0 +1,86 @@
+"""Configuration dataclasses used by the generic classification trainer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class ObjectConfig:
+    """Configuration for lazily importing and instantiating an object."""
+
+    target: str
+    params: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class OptimConfig(ObjectConfig):
+    """Configuration for optimizers."""
+
+
+@dataclass
+class TrainingConfig:
+    """Top-level training configuration."""
+
+    seed: int = 42
+    max_epochs: int = 20
+    device: str = "cpu"
+    log_every_n_steps: int = 10
+    output_dir: Path = Path("outputs")
+    dataset: ObjectConfig = field(default_factory=lambda: ObjectConfig(
+        target="classification.data.ToyClassificationDataModule",
+        params={},
+    ))
+    model: ObjectConfig = field(default_factory=lambda: ObjectConfig(
+        target="classification.models.MLPClassifier",
+        params={},
+    ))
+    optimizer: OptimConfig = field(default_factory=lambda: OptimConfig(
+        target="torch.optim.Adam",
+        params={"lr": 1e-3},
+    ))
+    scheduler: Optional[ObjectConfig] = None
+
+
+def load_config(path: Path) -> TrainingConfig:
+    """Load a :class:`TrainingConfig` from a JSON file."""
+
+    import json
+
+    defaults = TrainingConfig()
+
+    with path.open("r", encoding="utf-8") as fp:
+        payload: Dict[str, Any] = json.load(fp)
+
+    def parse_object(data: Optional[Dict[str, Any]], default: ObjectConfig) -> ObjectConfig:
+        if data is None:
+            return default
+        return ObjectConfig(target=data["target"], params=data.get("params", {}))
+
+    dataset_cfg = parse_object(payload.get("dataset"), defaults.dataset)
+    model_cfg = parse_object(payload.get("model"), defaults.model)
+
+    optim_cfg = payload.get("optimizer")
+    if optim_cfg is None:
+        optimizer = defaults.optimizer
+    else:
+        optimizer = OptimConfig(target=optim_cfg["target"], params=optim_cfg.get("params", {}))
+
+    scheduler_cfg = payload.get("scheduler")
+    scheduler = None
+    if scheduler_cfg is not None:
+        scheduler = ObjectConfig(target=scheduler_cfg["target"], params=scheduler_cfg.get("params", {}))
+
+    return TrainingConfig(
+        seed=payload.get("seed", defaults.seed),
+        max_epochs=payload.get("max_epochs", defaults.max_epochs),
+        device=payload.get("device", defaults.device),
+        log_every_n_steps=payload.get("log_every_n_steps", defaults.log_every_n_steps),
+        output_dir=Path(payload.get("output_dir", str(defaults.output_dir))),
+        dataset=dataset_cfg,
+        model=model_cfg,
+        optimizer=optimizer,
+        scheduler=scheduler,
+    )

--- a/classification/data.py
+++ b/classification/data.py
@@ -1,0 +1,107 @@
+"""Dataset utilities for interchangeable classification training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol, Sequence, Tuple
+
+import torch
+from sklearn.datasets import make_classification
+from torch.utils.data import DataLoader, Dataset, TensorDataset
+
+
+class ClassificationDataModule(Protocol):
+    """Protocol describing the expected behaviour of data modules."""
+
+    num_classes: int
+    input_shape: Sequence[int]
+
+    def train_dataloader(self) -> DataLoader:
+        ...
+
+    def val_dataloader(self) -> DataLoader:
+        ...
+
+    def test_dataloader(self) -> Optional[DataLoader]:
+        ...
+
+
+@dataclass
+class ToyDatasetConfig:
+    """Configuration for :class:`ToyClassificationDataModule`."""
+
+    num_samples: int = 2000
+    num_features: int = 20
+    num_classes: int = 3
+    class_sep: float = 1.0
+    test_split: float = 0.2
+    val_split: float = 0.1
+    batch_size: int = 64
+    num_workers: int = 0
+    seed: int = 42
+
+
+class ToyClassificationDataModule:
+    """Simple data module that generates synthetic tabular data."""
+
+    def __init__(self, **kwargs: object) -> None:
+        cfg = ToyDatasetConfig(**kwargs)
+        self.config = cfg
+
+        generator = torch.Generator().manual_seed(cfg.seed)
+        data, target = make_classification(
+            n_samples=cfg.num_samples,
+            n_features=cfg.num_features,
+            n_informative=cfg.num_features,
+            n_redundant=0,
+            n_repeated=0,
+            n_classes=cfg.num_classes,
+            class_sep=cfg.class_sep,
+            random_state=cfg.seed,
+        )
+
+        tensor_x = torch.tensor(data, dtype=torch.float32)
+        tensor_y = torch.tensor(target, dtype=torch.long)
+
+        test_size = int(cfg.num_samples * cfg.test_split)
+        val_size = int(cfg.num_samples * cfg.val_split)
+        train_size = cfg.num_samples - test_size - val_size
+        if train_size <= 0:
+            raise ValueError("Train split must contain at least one sample.")
+
+        self.train_set, self.val_set, self.test_set = torch.utils.data.random_split(
+            TensorDataset(tensor_x, tensor_y),
+            lengths=[train_size, val_size, test_size],
+            generator=generator,
+        )
+
+        self._train_loader = self._create_loader(self.train_set, shuffle=True)
+        self._val_loader = self._create_loader(self.val_set, shuffle=False)
+        self._test_loader = self._create_loader(self.test_set, shuffle=False)
+
+        self.num_classes = cfg.num_classes
+        self.input_shape = (cfg.num_features,)
+
+    def _create_loader(self, dataset: Dataset, *, shuffle: bool) -> DataLoader:
+        return DataLoader(
+            dataset,
+            batch_size=self.config.batch_size,
+            shuffle=shuffle,
+            num_workers=self.config.num_workers,
+        )
+
+    def train_dataloader(self) -> DataLoader:
+        return self._train_loader
+
+    def val_dataloader(self) -> DataLoader:
+        return self._val_loader
+
+    def test_dataloader(self) -> Optional[DataLoader]:
+        return self._test_loader
+
+
+def to_device(batch: Tuple[torch.Tensor, torch.Tensor], device: torch.device) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Move batch tensors to the given device."""
+
+    inputs, targets = batch
+    return inputs.to(device), targets.to(device)

--- a/classification/models.py
+++ b/classification/models.py
@@ -1,0 +1,42 @@
+"""Model definitions for interchangeable classification training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import torch
+from torch import nn
+
+
+@dataclass
+class MLPConfig:
+    """Configuration for :class:`MLPClassifier`."""
+
+    in_features: int
+    hidden_dims: Sequence[int] = (128, 64)
+    num_classes: int = 2
+    dropout: float = 0.0
+
+
+class MLPClassifier(nn.Module):
+    """Simple fully connected classifier."""
+
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__()
+        cfg = MLPConfig(**kwargs)  # type: ignore[arg-type]
+
+        layers: list[nn.Module] = []
+        input_dim = cfg.in_features
+        for hidden_dim in cfg.hidden_dims:
+            layers.append(nn.Linear(input_dim, hidden_dim))
+            layers.append(nn.ReLU())
+            if cfg.dropout > 0:
+                layers.append(nn.Dropout(p=cfg.dropout))
+            input_dim = hidden_dim
+        layers.append(nn.Linear(input_dim, cfg.num_classes))
+
+        self.network = nn.Sequential(*layers)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        return self.network(inputs)

--- a/classification/trainer.py
+++ b/classification/trainer.py
@@ -1,0 +1,138 @@
+"""Generic training loop for classification models."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, Dict, Optional, Type
+
+import torch
+from torch import nn
+from torch.optim.lr_scheduler import _LRScheduler
+from torch.utils.data import DataLoader
+
+from .config import ObjectConfig, TrainingConfig
+from .data import to_device
+
+
+class Trainer:
+    """Train and evaluate classification models with pluggable components."""
+
+    def __init__(self, config: TrainingConfig) -> None:
+        self.config = config
+        self.device = torch.device(config.device)
+        self.output_dir = config.output_dir
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        torch.manual_seed(config.seed)
+        torch.cuda.manual_seed_all(config.seed)
+
+        self.data_module = self._instantiate(config.dataset)
+        self.model: nn.Module = self._instantiate(config.model)
+        self.model.to(self.device)
+
+        self.optimizer = self._instantiate_optimizer(config.optimizer)
+        self.scheduler = self._instantiate_scheduler(config.scheduler)
+
+        self.criterion = nn.CrossEntropyLoss()
+
+    def _instantiate(self, cfg: ObjectConfig) -> Any:
+        module_name, class_name = cfg.target.rsplit(".", 1)
+        module = import_module(module_name)
+        target_cls: Any = getattr(module, class_name)
+        return target_cls(**cfg.params)
+
+    def _instantiate_optimizer(self, cfg: ObjectConfig) -> torch.optim.Optimizer:
+        module_name, class_name = cfg.target.rsplit(".", 1)
+        module = import_module(module_name)
+        optim_cls: Type[torch.optim.Optimizer] = getattr(module, class_name)
+        return optim_cls(self.model.parameters(), **cfg.params)
+
+    def _instantiate_scheduler(self, cfg: Optional[ObjectConfig]) -> Optional[_LRScheduler]:
+        if cfg is None:
+            return None
+        module_name, class_name = cfg.target.rsplit(".", 1)
+        module = import_module(module_name)
+        scheduler_cls: Type[_LRScheduler] = getattr(module, class_name)
+        return scheduler_cls(self.optimizer, **cfg.params)
+
+    def fit(self) -> None:
+        best_val_acc = 0.0
+        for epoch in range(1, self.config.max_epochs + 1):
+            train_metrics = self._run_epoch(self.data_module.train_dataloader(), train=True)
+            val_metrics = self._run_epoch(self.data_module.val_dataloader(), train=False)
+
+            val_acc = val_metrics["accuracy"]
+            if val_acc > best_val_acc:
+                best_val_acc = val_acc
+                self._save_checkpoint(epoch)
+
+            print(
+                f"Epoch {epoch}/{self.config.max_epochs} "
+                f"- train_loss: {train_metrics['loss']:.4f} train_acc: {train_metrics['accuracy']:.4f} "
+                f"- val_loss: {val_metrics['loss']:.4f} val_acc: {val_metrics['accuracy']:.4f}"
+            )
+
+            if self.scheduler is not None:
+                self.scheduler.step()
+
+        test_loader = self.data_module.test_dataloader()
+        if test_loader is not None:
+            test_metrics = self._run_epoch(test_loader, train=False)
+            print(
+                f"Test - loss: {test_metrics['loss']:.4f} accuracy: {test_metrics['accuracy']:.4f}"
+            )
+
+    def _run_epoch(self, dataloader: DataLoader, *, train: bool) -> Dict[str, float]:
+        if train:
+            self.model.train()
+        else:
+            self.model.eval()
+
+        total_loss = 0.0
+        total_correct = 0
+        total_samples = 0
+
+        for step, batch in enumerate(dataloader, start=1):
+            inputs, targets = to_device(batch, self.device)
+
+            with torch.set_grad_enabled(train):
+                outputs = self.model(inputs)
+                loss = self.criterion(outputs, targets)
+
+            if train:
+                self.optimizer.zero_grad()
+                loss.backward()
+                self.optimizer.step()
+
+            total_loss += loss.item() * inputs.size(0)
+            preds = outputs.argmax(dim=1)
+            total_correct += (preds == targets).sum().item()
+            total_samples += inputs.size(0)
+
+            if train and step % self.config.log_every_n_steps == 0:
+                accuracy = total_correct / max(total_samples, 1)
+                print(f"Step {step} - loss: {loss.item():.4f} accuracy: {accuracy:.4f}")
+
+        if total_samples == 0:
+            return {"loss": float("nan"), "accuracy": 0.0}
+
+        average_loss = total_loss / total_samples
+        accuracy = total_correct / total_samples
+        return {"loss": average_loss, "accuracy": accuracy}
+
+    def _save_checkpoint(self, epoch: int) -> None:
+        checkpoint_path = self.output_dir / "best_model.pt"
+        payload = {
+            "epoch": epoch,
+            "model_state_dict": self.model.state_dict(),
+            "optimizer_state_dict": self.optimizer.state_dict(),
+            "config": self.config,
+        }
+        torch.save(payload, checkpoint_path)
+
+
+def run_training(config: TrainingConfig) -> None:
+    """Convenience function for running the full training loop."""
+
+    trainer = Trainer(config)
+    trainer.fit()

--- a/configs/toy_classification.json
+++ b/configs/toy_classification.json
@@ -1,0 +1,34 @@
+{
+  "seed": 13,
+  "device": "cpu",
+  "max_epochs": 5,
+  "log_every_n_steps": 10,
+  "output_dir": "outputs/toy",
+  "dataset": {
+    "target": "classification.data.ToyClassificationDataModule",
+    "params": {
+      "num_samples": 1500,
+      "num_features": 32,
+      "num_classes": 4,
+      "batch_size": 128,
+      "val_split": 0.15,
+      "test_split": 0.15,
+      "seed": 13
+    }
+  },
+  "model": {
+    "target": "classification.models.MLPClassifier",
+    "params": {
+      "in_features": 32,
+      "hidden_dims": [256, 128, 64],
+      "num_classes": 4,
+      "dropout": 0.2
+    }
+  },
+  "optimizer": {
+    "target": "torch.optim.Adam",
+    "params": {
+      "lr": 0.001
+    }
+  }
+}

--- a/train_classifier.py
+++ b/train_classifier.py
@@ -1,0 +1,33 @@
+"""Command line entry point for the generic classification trainer."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from classification.config import load_config
+from classification.trainer import run_training
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("configs/toy_classification.json"),
+        help="Path to a JSON config file describing the training run.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.config.exists():
+        raise FileNotFoundError(f"Config file not found: {args.config}")
+
+    config = load_config(args.config)
+    run_training(config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a modular classification package with configurable data, model, and optimizer components
- provide a CLI entry point and sample JSON config for running training jobs
- document usage patterns and extension points in a dedicated README

## Testing
- python train_classifier.py --config configs/toy_classification.json *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68f1a63771308327a149158a032c2e57